### PR TITLE
feat (kontena) Support for namespaced kontena stacks

### DIFF
--- a/bin/kung
+++ b/bin/kung
@@ -88,7 +88,7 @@ case "$command" in
     DividerSuffix "$subcommand $@"
 
     if [ "$STACK" = "" ]; then
-      stack_name=$(cat kontena.yml | grep "^stack:" | rev | cut -d' ' -f1 | rev)
+      stack_name=$(cat kontena.yml | grep "^stack:" | rev | cut -d' ' -f1 | rev | sed 's/\//-/g')
     else
       stack_name=$STACK
     fi


### PR DESCRIPTION
Test without namespace:

```
$ echo "stack: foo-bar" | rev | cut -d' ' -f1 | cut -d'/' -f1 | rev
foo-bar
```

With namespace:

```
$ echo "stack: foo/bar" | rev | cut -d' ' -f1 | cut -d'/' -f1 | rev
bar
```